### PR TITLE
add SOA DS query record type

### DIFF
--- a/pydig/query_type.py
+++ b/pydig/query_type.py
@@ -24,6 +24,8 @@ class QueryType(Enum):
     NS = 2
     PTR = 12
     TXT = 16
+    SOA = 6
+    DS = 43
 
     @classmethod
     def get(cls, query_type):


### PR DESCRIPTION
Figured id share my local mods which  fetched the other records I was needing in my project.

works for me when using locally these with this added.

test file:
https://pastebin.com/6p1YGqcH

Example showing those records work from the above test script from those two minor additions.

```
python dns.py leonmarksmith.com
www.leonmarksmith.com. CNAME d2q2x1rz45wk7n.cloudfront.net
leonmarksmith.com. A 13.35.118.97
leonmarksmith.com. A 13.35.118.80
leonmarksmith.com. A 13.35.118.79
leonmarksmith.com. A 13.35.118.47
leonmarksmith.com. AAAA 2600:9000:20bf:400:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:ba00:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:b600:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:d200:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:3200:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:ce00:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:2400:1:45b4:d4c0:93a1
leonmarksmith.com. AAAA 2600:9000:20bf:a600:1:45b4:d4c0:93a1
leonmarksmith.com. NS ns-25-b.gandi.net.
leonmarksmith.com. NS ns-31-a.gandi.net.
leonmarksmith.com. NS ns-165-c.gandi.net.
leonmarksmith.com. SOA ns1.gandi.net. hostmaster.gandi.net. 1582761600 10800 3600 604800 10800
leonmarksmith.com. MX 10 in1-smtp.messagingengine.com.
leonmarksmith.com. MX 20 in2-smtp.messagingengine.com.
leonmarksmith.com. TXT "v=spf1 include:spf.messagingengine.com -all"
leonmarksmith.com. TXT "google-site-verification=5E3L2apQbDhaIDRh8--Flu4bC2GcYYlq15EgHVDUZXU"

Checking Domain A Record IPs RDNs/PTR
13.35.118.47 ==> server-13-35-118-47.mia3.r.cloudfront.net
13.35.118.79 ==> server-13-35-118-79.mia3.r.cloudfront.net
13.35.118.80 ==> server-13-35-118-80.mia3.r.cloudfront.net
13.35.118.97 ==> server-13-35-118-97.mia3.r.cloudfront.net

Checking MX Record IPs RDNs/PTR
in2-smtp.messagingengine.com ==> 64.147.123.51 ==> wmx1.messagingengine.com
in1-smtp.messagingengine.com ==> 66.111.4.75 ==> mx6.messagingengine.com

```

I also really think having something in your pydig which does something like the above all in one object or dictionary would be super helpful. The above test script loops through all the stuff which can have muliple records nicely and also grabs some other handy stuff people tend to need but have to manually search for.

Adding a custom record type "ANY" or "ALL"
        domain_dns = pydig.query(site, 'ANY')
Which returns all the records in one go it can find via looping would make this one of the best python dig tools out there.

I love the work and simple elegance of pydig btw its why im using it over dnspython.  Keep up the good work. :)
